### PR TITLE
Changes to group assignment

### DIFF
--- a/lipydomics/data.py
+++ b/lipydomics/data.py
@@ -112,6 +112,28 @@ Dataset.assign_groups
         for group_name in group_indices:
             self.group_indices[group_name] = group_indices[group_name]
 
+    def assign_groups_with_replicates(self, groups, n_replicates):
+        """
+Dataset.assign_groups_with_replicates
+    description:
+        Assign group identities to sample columns using a list of group names and number of replicates in each group.
+        This method should ideally be applied to label all samples and the number of groups * number of replicates
+        should be equal to the number of sample columns, BUT this is not enforced. A dictionary reflecting the group
+        assignments (in order of the group names provided and with the specified number of replicates in each group) is
+        produced and passed on to Dataset.assign_groups to actually make the group assignments
+    parameters:
+        groups (list(str)) -- list of group names
+        n_replicates (int) -- number of samples in each group
+"""
+        group_indices = {}
+        i = 0
+        for group in groups:
+            group_indices[group] = []
+            for j in range(n_replicates):
+                group_indices[group].append(i)
+                i += 1
+        self.assign_groups(group_indices)
+
     def get_data_bygroup(self, group_names, normed=False):
         """
 Dataset.get_data_bygroup

--- a/lipydomics/doc/lipydomics.data.html
+++ b/lipydomics/doc/lipydomics.data.html
@@ -97,6 +97,17 @@ description:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group_indices&nbsp;(dict(str:list(int)))&nbsp;--&nbsp;dictionary&nbsp;of&nbsp;group&nbsp;names&nbsp;mapped&nbsp;to&nbsp;the&nbsp;indices&nbsp;of&nbsp;sample&nbsp;columns&nbsp;<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;belonging&nbsp;to&nbsp;each&nbsp;group</tt></dd></dl>
 
+<dl><dt><a name="Dataset-assign_groups_with_replicates"><strong>assign_groups_with_replicates</strong></a>(self, groups, n_replicates)</dt><dd><tt><a href="#Dataset">Dataset</a>.assign_groups_with_replicates<br>
+&nbsp;&nbsp;&nbsp;&nbsp;description:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Assign&nbsp;group&nbsp;identities&nbsp;to&nbsp;sample&nbsp;columns&nbsp;using&nbsp;a&nbsp;list&nbsp;of&nbsp;group&nbsp;names&nbsp;and&nbsp;number&nbsp;of&nbsp;replicates&nbsp;in&nbsp;each&nbsp;group.<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This&nbsp;method&nbsp;should&nbsp;ideally&nbsp;be&nbsp;applied&nbsp;to&nbsp;label&nbsp;all&nbsp;samples&nbsp;and&nbsp;the&nbsp;number&nbsp;of&nbsp;groups&nbsp;*&nbsp;number&nbsp;of&nbsp;replicates<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;should&nbsp;be&nbsp;equal&nbsp;to&nbsp;the&nbsp;number&nbsp;of&nbsp;sample&nbsp;columns,&nbsp;BUT&nbsp;this&nbsp;is&nbsp;not&nbsp;enforced.&nbsp;A&nbsp;dictionary&nbsp;reflecting&nbsp;the&nbsp;group<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;assignments&nbsp;(in&nbsp;order&nbsp;of&nbsp;the&nbsp;group&nbsp;names&nbsp;provided&nbsp;and&nbsp;with&nbsp;the&nbsp;specified&nbsp;number&nbsp;of&nbsp;replicates&nbsp;in&nbsp;each&nbsp;group)&nbsp;is<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;produced&nbsp;and&nbsp;passed&nbsp;on&nbsp;to&nbsp;<a href="#Dataset">Dataset</a>.assign_groups&nbsp;to&nbsp;actually&nbsp;make&nbsp;the&nbsp;group&nbsp;assignments<br>
+&nbsp;&nbsp;&nbsp;&nbsp;parameters:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups&nbsp;(list(str))&nbsp;--&nbsp;list&nbsp;of&nbsp;group&nbsp;names<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;n_replicates&nbsp;(int)&nbsp;--&nbsp;number&nbsp;of&nbsp;samples&nbsp;in&nbsp;each&nbsp;group</tt></dd></dl>
+
 <dl><dt><a name="Dataset-get_data_bygroup"><strong>get_data_bygroup</strong></a>(self, group_names, normed=False)</dt><dd><tt><a href="#Dataset">Dataset</a>.get_data_bygroup<br>
 &nbsp;&nbsp;&nbsp;&nbsp;description:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Returns&nbsp;a&nbsp;subset&nbsp;(or&nbsp;multiple&nbsp;subsets)&nbsp;of&nbsp;the&nbsp;dataset&nbsp;as&nbsp;defined&nbsp;by&nbsp;group&nbsp;names.&nbsp;The&nbsp;group&nbsp;indices&nbsp;must&nbsp;be&nbsp;<br>

--- a/lipydomics/doc/lipydomics.identification.html
+++ b/lipydomics/doc/lipydomics.identification.html
@@ -48,6 +48,7 @@ description:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The&nbsp;method&nbsp;for&nbsp;making&nbsp;identifications&nbsp;is&nbsp;specified&nbsp;by&nbsp;the&nbsp;`level`&nbsp;param:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(low)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'theo_mz'&nbsp;--&nbsp;simple&nbsp;matching&nbsp;based&nbsp;on&nbsp;theoretical&nbsp;m/z<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'theo_mz_ccs'&nbsp;--&nbsp;match&nbsp;on&nbsp;theoretical&nbsp;m/z&nbsp;and&nbsp;CCS<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'meas_mz_rt_ccs'&nbsp;--&nbsp;match&nbsp;on&nbsp;m/z,&nbsp;rt,&nbsp;and&nbsp;CCS&nbsp;for&nbsp;<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(high)<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'any'&nbsp;--&nbsp;start&nbsp;at&nbsp;the&nbsp;highest&nbsp;level,&nbsp;then&nbsp;work&nbsp;downward<br>

--- a/lipydomics/plotting.py
+++ b/lipydomics/plotting.py
@@ -51,7 +51,11 @@ barplot_feature_bygroup
     # go through each matched feature and generate a plot
     for i in found_feat:
         mz, rt, ccs = dataset.labels[i]
-        put_id, put_lvl = dataset.feat_ids[i], dataset.feat_id_levels[i]
+        # check for identifications first
+        if dataset.feat_ids is not None:
+            put_id, put_lvl = dataset.feat_ids[i], dataset.feat_id_levels[i]
+        else:
+            put_id, put_lvl = '', ''
         if type(put_id) == list:
             put_id = put_id[0] 
 

--- a/lipydomics/test/__main__.py
+++ b/lipydomics/test/__main__.py
@@ -15,7 +15,8 @@ import os
 
 
 from lipydomics.test.data import (
-    dataset_init_mock1, dataset_normalize_mock1, dataset_getgroup_mock1, dataset_save_load_bin_mock1
+    dataset_init_mock1, dataset_normalize_mock1, dataset_getgroup_mock1, dataset_assign_groups_using_replicates_real1,
+    dataset_save_load_bin_mock1
 )
 from lipydomics.test.stats import (
     addanovap_mock1, addanovap_real1, addpca3_mock1, addpca3_real1, addplsda_mock1, addplsda_3groups_mock1, 
@@ -40,6 +41,7 @@ run_all_tests
         dataset_init_mock1,
         dataset_normalize_mock1,
         dataset_getgroup_mock1,
+        dataset_assign_groups_using_replicates_real1,
         dataset_save_load_bin_mock1,
         # test/stats
         addanovap_mock1,

--- a/lipydomics/test/data.py
+++ b/lipydomics/test/data.py
@@ -64,6 +64,34 @@ dataset_getgroup_mock1
     return True
 
 
+def dataset_assign_groups_using_replicates_real1():
+    """
+dataset_assign_groups_using_replicates_real1
+    description:
+        Loads the real data example from .csv then uses Dataset.assign_groups_and_replicates to assign groups and checks
+        that the indices are correct.
+
+        Test fails if Dataset.group_indices is not set as expected.
+    returns:
+        (bool) -- test pass (True) or fail (False)
+"""
+    dset = Dataset(os.path.join(os.path.dirname(__file__), 'real_data_1.csv'))
+    dset.assign_groups_with_replicates(['Par', 'Dap2', 'Dal2', 'Van4', 'Van8'], 4)
+    group_indices = {
+        'Par': [0, 1, 2, 3],
+        'Dap2': [4, 5, 6, 7],
+        'Dal2': [8, 9, 10, 11],
+        'Van4': [12, 13, 14, 15],
+        'Van8': [16, 17, 18, 19]
+    }
+    for group in dset.group_indices.keys():
+        if dset.group_indices[group] != group_indices[group]:
+            # indices are not the same
+            return False
+    # no group index mismatches were found
+    return True
+
+
 def dataset_save_load_bin_mock1():
     """
 dataset_save_load_bin_mock1
@@ -72,7 +100,7 @@ dataset_save_load_bin_mock1
         format. The binary file is then reloaded and presence of the groups and normalized data is verified.
 
         Test fails if there are any errors, if the .pickle file does not get produced, or if the reloaded Dataset does
-        not have the coorrect attributes. 
+        not have the correct attributes.
     returns:
         (bool) -- test pass (True) or fail (False)
 """


### PR DESCRIPTION
added a way to assign groups using a list of group names and number of replicates in each group to make assigning groups in bulk a bit easier (Fixes #16) 